### PR TITLE
Rename ReactiveOps to Fairwinds

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,5 @@
 The MIT License (MIT)
-Copyright (c) 2016 ReactiveOps
+Copyright (c) 2016 FairwindsOps Inc
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -4,8 +4,8 @@ dependencies: []
 
 galaxy_info:
 
-  author:              ReactiveOps
-  company:             ReactiveOps
+  author:              Fairwinds
+  company:             Fairwinds
   description: >
     Supervisor role
   license: MIT


### PR DESCRIPTION
Remaining mentions: 
```

```